### PR TITLE
增加cpu架构为arm64的订阅地址解析转换

### DIFF
--- a/scripts/clash_profile_conversion.sh
+++ b/scripts/clash_profile_conversion.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # 加载clash配置文件内容
 raw_content=$(cat ${Server_Dir}/temp/clash.yaml)
 
@@ -21,7 +22,13 @@ else
       echo "$decoded_content" > ${Server_Dir}/temp/clash_config.yaml
     else
       echo "解码后的内容不符合clash标准，尝试将其转换为标准格式"
-      ${Server_Dir}/tools/subconverter/subconverter -g &>> ${Server_Dir}/logs/subconverter.log
+
+      if [[ $CpuArch =~ "x86_64" || $CpuArch =~ "amd64" ]]; then
+        ${Server_Dir}/tools/subconverter/subconverter -g &>> ${Server_Dir}/logs/subconverter.log
+      elif [[ $CpuArch =~ "arm64" ]]; then
+        ${Server_Dir}/tools/subconverter/subconverter_arm64 -g &>> ${Server_Dir}/logs/subconverter.log
+      fi
+      
       converted_file=${Server_Dir}/temp/clash_config.yaml
       # 判断转换后的内容是否符合clash配置文件标准
       if awk '/^proxies:/{p=1} /^proxy-groups:/{g=1} /^rules:/{r=1} p&&g&&r{exit} END{if(p&&g&&r) exit 0; else exit 1}' $converted_file; then

--- a/start.sh
+++ b/start.sh
@@ -84,6 +84,7 @@ if [[ -z "$CpuArch" ]]; then
 	exit 1
 fi
 
+export CpuArch=$CpuArch
 
 ## 临时取消环境变量
 unset http_proxy
@@ -132,11 +133,12 @@ if_success $Text3 $Text4 $ReturnStatus
 
 
 ## 判断订阅内容是否符合clash配置文件标准，尝试转换（当前不支持对 x86_64 以外的CPU架构服务器进行clash配置文件检测和转换，此功能将在后续添加）
-if [[ $CpuArch =~ "x86_64" || $CpuArch =~ "amd64"  ]]; then
+if [[ $CpuArch =~ "x86_64" || $CpuArch =~ "amd64" || $CpuArch =~ "arm64" ]]; then
 	echo -e '\n判断订阅内容是否符合clash配置文件标准:'
 	bash $Server_Dir/scripts/clash_profile_conversion.sh
 	sleep 3
 fi
+
 
 
 ## Clash 配置文件重新格式化及配置


### PR DESCRIPTION
目前，软件本身支持cpu为arm64的运行，但是解析订阅地址时，arm64无法调用subconverter，无法完成订阅地址解析和转换。因此，我将subconverter的arm64版本加入到库中，使得脚本能正常运行