### PR TITLE
fix start.sh bugs

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -151,7 +151,7 @@ sed -e '/^port:/d'\
     -e '/^allow-lan"/d'\
     -e '/^mode:/d'\
     -e '/^log-level:/d'\
-    -e '/^external-controller:/d'
+    -e '/^external-controller:/d'\
     -e '/^secret:/d' > $Temp_Dir/proxy.txt
 
 # 合并形成新的config.yaml


### PR DESCRIPTION
sed缺少末尾的\，导致不能将proxy列表写入到config，所以启动之后proxy列表为空 
