### PR TITLE
Update start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -151,7 +151,7 @@ sed -e '/^port:/d'\
     -e '/^allow-lan"/d'\
     -e '/^mode:/d'\
     -e '/^log-level:/d'\
-    -e '/^external-controller:/d'
+    -e '/^external-controller:/d'\
     -e '/^secret:/d' > $Temp_Dir/proxy.txt
 
 # 合并形成新的config.yaml


### PR DESCRIPTION
A small issue with the script launch, missing a “\” will cause problems with the clash config.yaml configuration to be unusable after the launch when formatting and configuring clash is needed. 
启动脚本处的一个小问题，少一个“\”
会导致需要重新格式化及配置clash的config时，启动完成之后clash的config.yaml配置有问题无法正常使用